### PR TITLE
change password reset url according to store's domain name

### DIFF
--- a/app/mailers/spree/user_mailer.rb
+++ b/app/mailers/spree/user_mailer.rb
@@ -1,7 +1,7 @@
 module Spree
   class UserMailer < BaseMailer
     def reset_password_instructions(user, token, *args)
-      @edit_password_reset_url = spree.edit_spree_user_password_url(:reset_password_token => token)
+      @edit_password_reset_url = spree.edit_spree_user_password_url(:reset_password_token => token, :host => Spree::Config.site_url)
 
       mail(:to => user.email, :from => from_address,
           :subject => Spree::Config[:site_name] + ' ' +

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -14,12 +14,11 @@ feature 'Checkout', js: true do
   given!(:address) { create(:address, state: state, country: country) }
 
   background do
-    ActionMailer::Base.default_url_options[:host] = 'http://example.com'
     @product = create(:product, name: 'RoR Mug')
     @product.master.stock_items.first.update_column(:count_on_hand, 1)
 
-    ActionMailer::Base.default_url_options[:host] = 'http://example.com'
     Spree::Config[:enable_mail_delivery] = true
+    Spree::Config.site_url = 'http://example.com'
 
     # Bypass gateway error on checkout | ..or stub a gateway
     Spree::Config[:allow_checkout_on_gateway_error] = true


### PR DESCRIPTION
Previously, password reset link would always have domain set to demo.spreecommerce.com
